### PR TITLE
feat(vim): use system clipboard by default

### DIFF
--- a/vim/config
+++ b/vim/config
@@ -13,6 +13,9 @@ set laststatus=2  " Always display the status line
 set autoread      " Re-read buffers when they change on disk
 set autowrite     " Automatically :write before running commands
 
+" Use system clipboard by default
+set clipboard=unnamed
+
 set shell=/bin/bash
 
 " Exclude files from Ctrl-P and other indexing/checking/etc


### PR DESCRIPTION
Use the system clipboard by default, enabling easier copy and paste between vim and other applications.

Closes #29 