### PR TITLE
fix(fish): specify vi mode at startup

### DIFF
--- a/fish/tnez/functions/fish_user_key_bindings.fish
+++ b/fish/tnez/functions/fish_user_key_bindings.fish
@@ -1,4 +1,6 @@
 function fish_user_key_bindings
+    fish_vi_key_bindings
+
     bind -M insert -m default kj backward-char force-repaint
 
     for mode in insert default visual


### PR DESCRIPTION
Add entry to specify vi mode when starting up fish shell.

Closes #28 