### PR TITLE
feat(vim): add zen writing mode

### DIFF
--- a/vim/config
+++ b/vim/config
@@ -62,6 +62,7 @@ Plug 'qpkorr/vim-bufkill'
 
 " Looks
 Plug 'danielwe/base16-vim'
+Plug 'junegunn/goyo.vim'
 Plug 'vim-airline/vim-airline'
 Plug 'vim-airline/vim-airline-themes'
 


### PR DESCRIPTION
Install the `Goyo` plugin to enable distraction free writing useful for markdown
and things like that.